### PR TITLE
`fileinto :flags` not properly handling flag arguments

### DIFF
--- a/gen/location.hh
+++ b/gen/location.hh
@@ -1,8 +1,8 @@
-// A Bison parser, made by GNU Bison 3.0.2.
+// A Bison parser, made by GNU Bison 3.0.4.
 
 // Locations for Bison parsers in C++
 
-// Copyright (C) 2002-2013 Free Software Foundation, Inc.
+// Copyright (C) 2002-2015 Free Software Foundation, Inc.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@
 
 
 namespace yy {
-#line 46 "gen/location.hh" // location.cc:332
+#line 46 "gen/location.hh" // location.cc:337
   /// Abstract a location.
   class location
   {
@@ -111,36 +111,42 @@ namespace yy {
     position end;
   };
 
-  /// Join two location objects to create a location.
-  inline location operator+ (location res, const location& end)
+  /// Join two locations, in place.
+  inline location& operator+= (location& res, const location& end)
   {
     res.end = end.end;
     return res;
   }
 
-  /// Change end position in place.
+  /// Join two locations.
+  inline location operator+ (location res, const location& end)
+  {
+    return res += end;
+  }
+
+  /// Add \a width columns to the end position, in place.
   inline location& operator+= (location& res, int width)
   {
     res.columns (width);
     return res;
   }
 
-  /// Change end position.
+  /// Add \a width columns to the end position.
   inline location operator+ (location res, int width)
   {
     return res += width;
   }
 
-  /// Change end position in place.
+  /// Subtract \a width columns to the end position, in place.
   inline location& operator-= (location& res, int width)
   {
     return res += -width;
   }
 
-  /// Change end position.
-  inline location operator- (const location& begin, int width)
+  /// Subtract \a width columns to the end position.
+  inline location operator- (location res, int width)
   {
-    return begin + -width;
+    return res -= width;
   }
 
   /// Compare two location objects.
@@ -168,8 +174,7 @@ namespace yy {
   operator<< (std::basic_ostream<YYChar>& ostr, const location& loc)
   {
     unsigned int end_col = 0 < loc.end.column ? loc.end.column - 1 : 0;
-    ostr << loc.begin// << "(" << loc.end << ") "
-;
+    ostr << loc.begin;
     if (loc.end.filename
         && (!loc.begin.filename
             || *loc.begin.filename != *loc.end.filename))
@@ -183,5 +188,5 @@ namespace yy {
 
 
 } // yy
-#line 187 "gen/location.hh" // location.cc:332
+#line 192 "gen/location.hh" // location.cc:337
 #endif // !YY_YY_GEN_LOCATION_HH_INCLUDED

--- a/gen/position.hh
+++ b/gen/position.hh
@@ -1,8 +1,8 @@
-// A Bison parser, made by GNU Bison 3.0.2.
+// A Bison parser, made by GNU Bison 3.0.4.
 
 // Positions for Bison parsers in C++
 
-// Copyright (C) 2002-2013 Free Software Foundation, Inc.
+// Copyright (C) 2002-2015 Free Software Foundation, Inc.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -52,7 +52,7 @@
 
 
 namespace yy {
-#line 56 "gen/position.hh" // location.cc:332
+#line 56 "gen/position.hh" // location.cc:337
   /// Abstract a position.
   class position
   {
@@ -114,7 +114,7 @@ namespace yy {
     }
   };
 
-  /// Add and assign a position.
+  /// Add \a width columns, in place.
   inline position&
   operator+= (position& res, int width)
   {
@@ -122,21 +122,21 @@ namespace yy {
     return res;
   }
 
-  /// Add two position objects.
+  /// Add \a width columns.
   inline position
   operator+ (position res, int width)
   {
     return res += width;
   }
 
-  /// Add and assign a position.
+  /// Subtract \a width columns, in place.
   inline position&
   operator-= (position& res, int width)
   {
     return res += -width;
   }
 
-  /// Add two position objects.
+  /// Subtract \a width columns.
   inline position
   operator- (position res, int width)
   {
@@ -176,5 +176,5 @@ namespace yy {
 
 
 } // yy
-#line 180 "gen/position.hh" // location.cc:332
+#line 180 "gen/position.hh" // location.cc:337
 #endif // !YY_YY_GEN_POSITION_HH_INCLUDED

--- a/gen/sieve_parser.tab.cc
+++ b/gen/sieve_parser.tab.cc
@@ -1,8 +1,8 @@
-// A Bison parser, made by GNU Bison 3.0.2.
+// A Bison parser, made by GNU Bison 3.0.4.
 
 // Skeleton implementation for Bison LALR(1) parsers in C++
 
-// Copyright (C) 2002-2013 Free Software Foundation, Inc.
+// Copyright (C) 2002-2015 Free Software Foundation, Inc.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@
 
 // First part of user declarations.
 
-#line 37 "gen/sieve_parser.tab.cc" // lalr1.cc:399
+#line 37 "gen/sieve_parser.tab.cc" // lalr1.cc:404
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -47,14 +47,14 @@
 
 // User implementation prologue.
 
-#line 51 "gen/sieve_parser.tab.cc" // lalr1.cc:407
+#line 51 "gen/sieve_parser.tab.cc" // lalr1.cc:412
 // Unqualified %code blocks.
-#line 33 "src/sieve_parser.yy" // lalr1.cc:408
+#line 33 "src/sieve_parser.yy" // lalr1.cc:413
 
 #include "sieve_driver.hh"
 #include "sieve_scanner.hh"
 
-#line 58 "gen/sieve_parser.tab.cc" // lalr1.cc:408
+#line 58 "gen/sieve_parser.tab.cc" // lalr1.cc:413
 
 
 #ifndef YY_
@@ -131,7 +131,7 @@
 #endif // !YYDEBUG
 
 #define yyerrok         (yyerrstatus_ = 0)
-#define yyclearin       (yyempty = true)
+#define yyclearin       (yyla.clear ())
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
@@ -140,7 +140,7 @@
 
 
 namespace yy {
-#line 144 "gen/sieve_parser.tab.cc" // lalr1.cc:474
+#line 144 "gen/sieve_parser.tab.cc" // lalr1.cc:479
 
   /* Return YYSTR after stripping away unnecessary quotes and
      backslashes, so that it's suitable for yyerror.  The heuristic is
@@ -204,7 +204,7 @@ namespace yy {
   // by_state.
   inline
   sieve_parser::by_state::by_state ()
-    : state (empty)
+    : state (empty_state)
   {}
 
   inline
@@ -214,10 +214,17 @@ namespace yy {
 
   inline
   void
+  sieve_parser::by_state::clear ()
+  {
+    state = empty_state;
+  }
+
+  inline
+  void
   sieve_parser::by_state::move (by_state& that)
   {
     state = that.state;
-    that.state = empty;
+    that.clear ();
   }
 
   inline
@@ -229,7 +236,10 @@ namespace yy {
   sieve_parser::symbol_number_type
   sieve_parser::by_state::type_get () const
   {
-    return state == empty ? 0 : yystos_[state];
+    if (state == empty_state)
+      return empty_symbol;
+    else
+      return yystos_[state];
   }
 
   inline
@@ -269,7 +279,7 @@ namespace yy {
     }
 
     // that is emptied.
-    that.type = empty;
+    that.type = empty_symbol;
   }
 
   inline
@@ -327,6 +337,10 @@ namespace yy {
     std::ostream& yyoutput = yyo;
     YYUSE (yyoutput);
     symbol_number_type yytype = yysym.type_get ();
+    // Avoid a (spurious) G++ 4.8 warning about "array subscript is
+    // below array bounds".
+    if (yysym.empty ())
+      std::abort ();
     yyo << (yytype < yyntokens_ ? "token" : "nterm")
         << ' ' << yytname_[yytype] << " ("
         << yysym.location << ": ";
@@ -411,9 +425,6 @@ namespace yy {
   int
   sieve_parser::parse ()
   {
-    /// Whether yyla contains a lookahead.
-    bool yyempty = true;
-
     // State.
     int yyn;
     /// Length of the RHS of the rule being reduced.
@@ -440,12 +451,12 @@ namespace yy {
 
 
     // User initialization code.
-    #line 26 "src/sieve_parser.yy" // lalr1.cc:729
+    #line 26 "src/sieve_parser.yy" // lalr1.cc:745
 {
     yyla.location.begin.filename = yyla.location.end.filename = &driver.file;
 }
 
-#line 449 "gen/sieve_parser.tab.cc" // lalr1.cc:729
+#line 460 "gen/sieve_parser.tab.cc" // lalr1.cc:745
 
     /* Initialize the stack.  The initial state will be set in
        yynewstate, since the latter expects the semantical and the
@@ -473,7 +484,7 @@ namespace yy {
       goto yydefault;
 
     // Read a lookahead token.
-    if (yyempty)
+    if (yyla.empty ())
       {
         YYCDEBUG << "Reading a token: ";
         try
@@ -486,7 +497,6 @@ namespace yy {
             error (yyexc);
             goto yyerrlab1;
           }
-        yyempty = false;
       }
     YY_SYMBOL_PRINT ("Next token is", yyla);
 
@@ -505,9 +515,6 @@ namespace yy {
         yyn = -yyn;
         goto yyreduce;
       }
-
-    // Discard the token being shifted.
-    yyempty = true;
 
     // Count tokens shifted since error; after three, turn off error status.
     if (yyerrstatus_)
@@ -578,15 +585,15 @@ namespace yy {
           switch (yyn)
             {
   case 5:
-#line 84 "src/sieve_parser.yy" // lalr1.cc:847
+#line 84 "src/sieve_parser.yy" // lalr1.cc:859
     {
             driver.add_required_modules( yystack_[1].value.as< std::vector<std::string> > () );
         }
-#line 586 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 593 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 6:
-#line 88 "src/sieve_parser.yy" // lalr1.cc:847
+#line 88 "src/sieve_parser.yy" // lalr1.cc:859
     {
             if (!driver.supports_module("imap4flags") && (yystack_[2].value.as< std::string > () == "addflag" || yystack_[2].value.as< std::string > () == "setflag" || yystack_[2].value.as< std::string > () == "removeflag" || yystack_[2].value.as< std::string > () == "hasflag")) {
                 driver.error(yystack_[2].location, "Unrecognized command \"" + yystack_[2].value.as< std::string > () + "\".", "Hint: require imap4flags");
@@ -652,9 +659,29 @@ namespace yy {
                 YYABORT;
             }
 
-            if (yystack_[2].value.as< std::string > () == "fileinto" && (yystack_[1].value.as< std::vector<std::string> > ().size() > 2 || yystack_[1].value.as< std::vector<std::string> > ().size() < 1)) {
-                driver.error(yystack_[1].location, "Incorrect arguments to \"fileinto\" command.", "Syntax:   fileinto [\":flags\"][\":copy\"] <folder: string>");
-                YYABORT;
+            if (yystack_[2].value.as< std::string > () == "fileinto") {
+                std::string suggestion = "Syntax:   fileinto [\":flags\" <list-of-flags: string-list>][\":copy\"] <folder: string>";
+
+                if (yystack_[1].value.as< std::vector<std::string> > ().size() < 1) {
+                    driver.error(yystack_[1].location, "Incorrect arguments to \"fileinto\" command.", suggestion);
+                    YYABORT;
+                }
+
+                int minArguments = 1;
+
+                if (std::find(yystack_[1].value.as< std::vector<std::string> > ().begin(), yystack_[1].value.as< std::vector<std::string> > ().end(), ":flags") != yystack_[1].value.as< std::vector<std::string> > ().end()) {
+                    minArguments += 2;
+                }
+
+                if (std::find(yystack_[1].value.as< std::vector<std::string> > ().begin(), yystack_[1].value.as< std::vector<std::string> > ().end(), ":copy") != yystack_[1].value.as< std::vector<std::string> > ().end()) {
+                    minArguments++;
+                }
+
+                // verify minimum number of arguments
+                if (yystack_[1].value.as< std::vector<std::string> > ().size() < minArguments) {
+                    driver.error(yystack_[1].location, "Incorrect number of arguments to \"fileinto\" command.", suggestion);
+                    YYABORT;
+                }
             }
 
             if (yystack_[2].value.as< std::string > () == "redirect" && (yystack_[1].value.as< std::vector<std::string> > ().size() > 2 || yystack_[1].value.as< std::vector<std::string> > ().size() < 1)) {
@@ -689,11 +716,11 @@ namespace yy {
                 YYABORT;
             }
         }
-#line 693 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 720 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 7:
-#line 191 "src/sieve_parser.yy" // lalr1.cc:847
+#line 211 "src/sieve_parser.yy" // lalr1.cc:859
     {
             if (!driver.supports_module("include") && (yystack_[1].value.as< std::string > () == "return")) {
                 driver.error(yystack_[1].location, "Unrecognized command \"" + yystack_[1].value.as< std::string > () + "\".", "Hint: require include");
@@ -735,22 +762,22 @@ namespace yy {
                 YYABORT;
             }
         }
-#line 739 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 766 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 8:
-#line 233 "src/sieve_parser.yy" // lalr1.cc:847
+#line 253 "src/sieve_parser.yy" // lalr1.cc:859
     {
             if (!driver.supports_module("foreverypart")) {
                 driver.error(yystack_[1].location, "Unrecognized action \"foreverypart\".", "Hint: require foreverypart");
                 YYABORT;
             }
         }
-#line 750 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 777 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 9:
-#line 240 "src/sieve_parser.yy" // lalr1.cc:847
+#line 260 "src/sieve_parser.yy" // lalr1.cc:859
     {
             if (!driver.supports_module("foreverypart")) {
                 driver.error(yystack_[3].location, "Unrecognized action \"foreverypart\".", "Hint: require foreverypart");
@@ -762,59 +789,59 @@ namespace yy {
                 YYABORT;
             }
         }
-#line 766 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 793 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 17:
-#line 264 "src/sieve_parser.yy" // lalr1.cc:847
+#line 284 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = yystack_[0].value.as< std::vector<std::string> > (); }
-#line 772 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 799 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 18:
-#line 265 "src/sieve_parser.yy" // lalr1.cc:847
+#line 285 "src/sieve_parser.yy" // lalr1.cc:859
     { yystack_[1].value.as< std::vector<std::string> > ().insert(yystack_[1].value.as< std::vector<std::string> > ().end(), yystack_[0].value.as< std::vector<std::string> > ().begin(), yystack_[0].value.as< std::vector<std::string> > ().end()); yylhs.value.as< std::vector<std::string> > () = yystack_[1].value.as< std::vector<std::string> > (); }
-#line 778 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 805 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 19:
-#line 266 "src/sieve_parser.yy" // lalr1.cc:847
+#line 286 "src/sieve_parser.yy" // lalr1.cc:859
     { yystack_[1].value.as< std::vector<std::string> > ().insert(yystack_[1].value.as< std::vector<std::string> > ().end(), yystack_[0].value.as< std::vector<std::string> > ().begin(), yystack_[0].value.as< std::vector<std::string> > ().end()); yylhs.value.as< std::vector<std::string> > () = yystack_[1].value.as< std::vector<std::string> > (); }
-#line 784 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 811 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 20:
-#line 267 "src/sieve_parser.yy" // lalr1.cc:847
+#line 287 "src/sieve_parser.yy" // lalr1.cc:859
     { yystack_[1].value.as< std::vector<std::string> > ().insert(yystack_[1].value.as< std::vector<std::string> > ().end(), yystack_[0].value.as< std::vector<std::string> > ().begin(), yystack_[0].value.as< std::vector<std::string> > ().end()); yylhs.value.as< std::vector<std::string> > () = yystack_[1].value.as< std::vector<std::string> > (); }
-#line 790 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 817 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 21:
-#line 268 "src/sieve_parser.yy" // lalr1.cc:847
+#line 288 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = yystack_[0].value.as< std::vector<std::string> > (); }
-#line 796 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 823 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 22:
-#line 269 "src/sieve_parser.yy" // lalr1.cc:847
+#line 289 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = yystack_[0].value.as< std::vector<std::string> > (); }
-#line 802 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 829 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 23:
-#line 272 "src/sieve_parser.yy" // lalr1.cc:847
+#line 292 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = yystack_[0].value.as< std::vector<std::string> > (); }
-#line 808 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 835 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 24:
-#line 273 "src/sieve_parser.yy" // lalr1.cc:847
+#line 293 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = std::vector<std::string>( 1, std::to_string(yystack_[0].value.as< int > ()) ); }
-#line 814 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 841 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 25:
-#line 275 "src/sieve_parser.yy" // lalr1.cc:847
+#line 295 "src/sieve_parser.yy" // lalr1.cc:859
     {
             if ( !driver.supports_module("index") && yystack_[0].value.as< std::string > () == ":index" ) {
                 driver.error(yystack_[0].location, "Unrecognized tag \"" + yystack_[0].value.as< std::string > () + "\".", "Hint: require index");
@@ -838,29 +865,29 @@ namespace yy {
 
             yylhs.value.as< std::vector<std::string> > () = std::vector<std::string>(1, yystack_[0].value.as< std::string > ());
         }
-#line 842 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 869 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 26:
-#line 300 "src/sieve_parser.yy" // lalr1.cc:847
+#line 320 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = yystack_[1].value.as< std::vector<std::string> > (); }
-#line 848 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 875 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 27:
-#line 303 "src/sieve_parser.yy" // lalr1.cc:847
+#line 323 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = yystack_[0].value.as< std::vector<std::string> > (); }
-#line 854 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 881 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 28:
-#line 304 "src/sieve_parser.yy" // lalr1.cc:847
+#line 324 "src/sieve_parser.yy" // lalr1.cc:859
     { yystack_[2].value.as< std::vector<std::string> > ().insert(yystack_[2].value.as< std::vector<std::string> > ().end(), yystack_[0].value.as< std::vector<std::string> > ().begin(), yystack_[0].value.as< std::vector<std::string> > ().end()); yylhs.value.as< std::vector<std::string> > () = yystack_[2].value.as< std::vector<std::string> > (); }
-#line 860 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 887 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 29:
-#line 308 "src/sieve_parser.yy" // lalr1.cc:847
+#line 328 "src/sieve_parser.yy" // lalr1.cc:859
     {
         std::transform(yystack_[1].value.as< std::string > ().begin(), yystack_[1].value.as< std::string > ().end(), yystack_[1].value.as< std::string > ().begin(), ::tolower);
         if (!driver.valid_test(yystack_[1].value.as< std::string > ())) {
@@ -890,59 +917,59 @@ namespace yy {
 
         yystack_[0].value.as< std::vector<std::string> > ().push_back(yystack_[1].value.as< std::string > ());
      }
-#line 894 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 921 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 30:
-#line 337 "src/sieve_parser.yy" // lalr1.cc:847
+#line 357 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = std::vector<std::string>(1, "true"); }
-#line 900 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 927 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 31:
-#line 338 "src/sieve_parser.yy" // lalr1.cc:847
+#line 358 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = std::vector<std::string>(1, "false"); }
-#line 906 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 933 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 32:
-#line 341 "src/sieve_parser.yy" // lalr1.cc:847
+#line 361 "src/sieve_parser.yy" // lalr1.cc:859
     {yylhs.value.as< std::vector<std::string> > () = std::vector<std::string>(1, yystack_[0].value.as< std::string > ()); }
-#line 912 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 939 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 33:
-#line 342 "src/sieve_parser.yy" // lalr1.cc:847
+#line 362 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = yystack_[1].value.as< std::vector<std::string> > (); }
-#line 918 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 945 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 34:
-#line 345 "src/sieve_parser.yy" // lalr1.cc:847
+#line 365 "src/sieve_parser.yy" // lalr1.cc:859
     {yylhs.value.as< std::vector<std::string> > () = std::vector<std::string>(1, yystack_[0].value.as< std::string > ()); }
-#line 924 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 951 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 35:
-#line 346 "src/sieve_parser.yy" // lalr1.cc:847
+#line 366 "src/sieve_parser.yy" // lalr1.cc:859
     { yystack_[2].value.as< std::vector<std::string> > ().push_back(yystack_[0].value.as< std::string > ()); yylhs.value.as< std::vector<std::string> > () = yystack_[2].value.as< std::vector<std::string> > (); }
-#line 930 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 957 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 36:
-#line 349 "src/sieve_parser.yy" // lalr1.cc:847
+#line 369 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< int > () = yystack_[0].value.as< int > (); }
-#line 936 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 963 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
   case 37:
-#line 350 "src/sieve_parser.yy" // lalr1.cc:847
+#line 370 "src/sieve_parser.yy" // lalr1.cc:859
     { yylhs.value.as< int > () = yystack_[1].value.as< int > (); }
-#line 942 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 969 "gen/sieve_parser.tab.cc" // lalr1.cc:859
     break;
 
 
-#line 946 "gen/sieve_parser.tab.cc" // lalr1.cc:847
+#line 973 "gen/sieve_parser.tab.cc" // lalr1.cc:859
             default:
               break;
             }
@@ -970,8 +997,7 @@ namespace yy {
     if (!yyerrstatus_)
       {
         ++yynerrs_;
-        error (yyla.location, yysyntax_error_ (yystack_[0].state,
-                                           yyempty ? yyempty_ : yyla.type_get ()));
+        error (yyla.location, yysyntax_error_ (yystack_[0].state, yyla));
       }
 
 
@@ -984,10 +1010,10 @@ namespace yy {
         // Return failure if at end of input.
         if (yyla.type_get () == yyeof_)
           YYABORT;
-        else if (!yyempty)
+        else if (!yyla.empty ())
           {
             yy_destroy_ ("Error: discarding", yyla);
-            yyempty = true;
+            yyla.clear ();
           }
       }
 
@@ -1063,7 +1089,7 @@ namespace yy {
     goto yyreturn;
 
   yyreturn:
-    if (!yyempty)
+    if (!yyla.empty ())
       yy_destroy_ ("Cleanup: discarding lookahead", yyla);
 
     /* Do not reclaim the symbols of the rule whose action triggered
@@ -1083,7 +1109,7 @@ namespace yy {
                  << std::endl;
         // Do not try to display the values of the reclaimed symbols,
         // as their printer might throw an exception.
-        if (!yyempty)
+        if (!yyla.empty ())
           yy_destroy_ (YY_NULLPTR, yyla);
 
         while (1 < yystack_.size ())
@@ -1103,9 +1129,8 @@ namespace yy {
 
   // Generate an error message.
   std::string
-  sieve_parser::yysyntax_error_ (state_type yystate, symbol_number_type yytoken) const
+  sieve_parser::yysyntax_error_ (state_type yystate, const symbol_type& yyla) const
   {
-    std::string yyres;
     // Number of reported tokens (one for the "unexpected", one per
     // "expected").
     size_t yycount = 0;
@@ -1119,7 +1144,7 @@ namespace yy {
          the only way this function was invoked is if the default action
          is an error action.  In that case, don't check for expected
          tokens because there are none.
-       - The only way there can be no lookahead present (in yytoken) is
+       - The only way there can be no lookahead present (in yyla) is
          if this state is a consistent state with a default action.
          Thus, detecting the absence of a lookahead is sufficient to
          determine that there is no unexpected or expected token to
@@ -1139,8 +1164,9 @@ namespace yy {
          token that will not be accepted due to an error action in a
          later state.
     */
-    if (yytoken != yyempty_)
+    if (!yyla.empty ())
       {
+        int yytoken = yyla.type_get ();
         yyarg[yycount++] = yytname_[yytoken];
         int yyn = yypact_[yystate];
         if (!yy_pact_value_is_default_ (yyn))
@@ -1183,6 +1209,7 @@ namespace yy {
 #undef YYCASE_
       }
 
+    std::string yyres;
     // Argument number.
     size_t yyi = 0;
     for (char const* yyp = yyformat; *yyp; ++yyp)
@@ -1316,10 +1343,10 @@ namespace yy {
   const unsigned short int
   sieve_parser::yyrline_[] =
   {
-       0,    77,    77,    78,    79,    83,    87,   190,   232,   239,
-     251,   252,   253,   256,   257,   260,   261,   264,   265,   266,
-     267,   268,   269,   272,   273,   274,   300,   303,   304,   308,
-     337,   338,   341,   342,   345,   346,   349,   350
+       0,    77,    77,    78,    79,    83,    87,   210,   252,   259,
+     271,   272,   273,   276,   277,   280,   281,   284,   285,   286,
+     287,   288,   289,   292,   293,   294,   320,   323,   324,   328,
+     357,   358,   361,   362,   365,   366,   369,   370
   };
 
   // Print the state stack on the debug stream.
@@ -1354,8 +1381,8 @@ namespace yy {
 
 
 } // yy
-#line 1358 "gen/sieve_parser.tab.cc" // lalr1.cc:1155
-#line 353 "src/sieve_parser.yy" // lalr1.cc:1156
+#line 1385 "gen/sieve_parser.tab.cc" // lalr1.cc:1167
+#line 373 "src/sieve_parser.yy" // lalr1.cc:1168
 
 
 void yy::sieve_parser::error( const location_type &l, const std::string &m ) {

--- a/gen/sieve_parser.tab.hh
+++ b/gen/sieve_parser.tab.hh
@@ -1,8 +1,8 @@
-// A Bison parser, made by GNU Bison 3.0.2.
+// A Bison parser, made by GNU Bison 3.0.4.
 
 // Skeleton interface for Bison LALR(1) parsers in C++
 
-// Copyright (C) 2002-2013 Free Software Foundation, Inc.
+// Copyright (C) 2002-2015 Free Software Foundation, Inc.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -40,7 +40,7 @@
 #ifndef YY_YY_GEN_SIEVE_PARSER_TAB_HH_INCLUDED
 # define YY_YY_GEN_SIEVE_PARSER_TAB_HH_INCLUDED
 // //                    "%code requires" blocks.
-#line 12 "src/sieve_parser.yy" // lalr1.cc:387
+#line 12 "src/sieve_parser.yy" // lalr1.cc:392
 
 #include <algorithm>
 #include <string>
@@ -53,13 +53,14 @@ namespace sieve {
 
 typedef void* yyscan_t;
 
-#line 57 "gen/sieve_parser.tab.hh" // lalr1.cc:387
+#line 57 "gen/sieve_parser.tab.hh" // lalr1.cc:392
 
 
-# include <vector>
+# include <cstdlib> // std::abort
 # include <iostream>
 # include <stdexcept>
 # include <string>
+# include <vector>
 # include "stack.hh"
 # include "location.hh"
 
@@ -129,7 +130,7 @@ typedef void* yyscan_t;
 
 
 namespace yy {
-#line 133 "gen/sieve_parser.tab.hh" // lalr1.cc:387
+#line 134 "gen/sieve_parser.tab.hh" // lalr1.cc:392
 
 
 
@@ -343,8 +344,11 @@ namespace yy {
     /// (External) token type, as returned by yylex.
     typedef token::yytokentype token_type;
 
-    /// Internal symbol number.
+    /// Symbol type: an internal symbol number.
     typedef int symbol_number_type;
+
+    /// The symbol type number to denote an empty symbol.
+    enum { empty_symbol = -2 };
 
     /// Internal symbol number for tokens (subsumed by symbol_number_type).
     typedef unsigned char token_number_type;
@@ -383,7 +387,14 @@ namespace yy {
                     const semantic_type& v,
                     const location_type& l);
 
+      /// Destroy the symbol.
       ~basic_symbol ();
+
+      /// Destroy contents, and record that is empty.
+      void clear ();
+
+      /// Whether empty.
+      bool empty () const;
 
       /// Destructive move, \a s is emptied into this.
       void move (basic_symbol& s);
@@ -414,21 +425,23 @@ namespace yy {
       /// Constructor from (external) token numbers.
       by_type (kind_type t);
 
+      /// Record that this symbol is empty.
+      void clear ();
+
       /// Steal the symbol type from \a that.
       void move (by_type& that);
 
       /// The (internal) type number (corresponding to \a type).
-      /// -1 when this symbol is empty.
+      /// \a empty when empty.
       symbol_number_type type_get () const;
 
       /// The token.
       token_type token () const;
 
-      enum { empty = 0 };
-
       /// The symbol type.
-      /// -1 when this symbol is empty.
-      token_number_type type;
+      /// \a empty_symbol when empty.
+      /// An int, not token_number_type, to be able to store empty_symbol.
+      int type;
     };
 
     /// "External" symbols: returned by the scanner.
@@ -564,9 +577,9 @@ namespace yy {
 
     /// Generate an error message.
     /// \param yystate   the state where the error occurred.
-    /// \param yytoken   the lookahead token type, or yyempty_.
+    /// \param yyla      the lookahead token.
     virtual std::string yysyntax_error_ (state_type yystate,
-                                         symbol_number_type yytoken) const;
+                                         const symbol_type& yyla) const;
 
     /// Compute post-reduction state.
     /// \param yystate   the current state
@@ -669,16 +682,21 @@ namespace yy {
       /// Copy constructor.
       by_state (const by_state& other);
 
+      /// Record that this symbol is empty.
+      void clear ();
+
       /// Steal the symbol type from \a that.
       void move (by_state& that);
 
       /// The (internal) type number (corresponding to \a state).
-      /// "empty" when empty.
+      /// \a empty_symbol when empty.
       symbol_number_type type_get () const;
 
-      enum { empty = 0 };
+      /// The state number used to denote an empty symbol.
+      enum { empty_state = -1 };
 
       /// The state.
+      /// \a empty when empty.
       state_type state;
     };
 
@@ -719,13 +737,12 @@ namespace yy {
     /// Pop \a n symbols the three stacks.
     void yypop_ (unsigned int n = 1);
 
-    // Constants.
+    /// Constants.
     enum
     {
       yyeof_ = 0,
       yylast_ = 94,     ///< Last index in yytable_.
       yynnts_ = 13,  ///< Number of nonterminal symbols.
-      yyempty_ = -2,
       yyfinal_ = 30, ///< Termination state number.
       yyterror_ = 1,
       yyerrcode_ = 256,
@@ -909,8 +926,18 @@ namespace yy {
   inline
   sieve_parser::basic_symbol<Base>::~basic_symbol ()
   {
+    clear ();
+  }
+
+  template <typename Base>
+  inline
+  void
+  sieve_parser::basic_symbol<Base>::clear ()
+  {
     // User destructor.
     symbol_number_type yytype = this->type_get ();
+    basic_symbol<Base>& yysym = *this;
+    (void) yysym;
     switch (yytype)
     {
    default:
@@ -945,6 +972,15 @@ namespace yy {
         break;
     }
 
+    Base::clear ();
+  }
+
+  template <typename Base>
+  inline
+  bool
+  sieve_parser::basic_symbol<Base>::empty () const
+  {
+    return Base::type_get () == empty_symbol;
   }
 
   template <typename Base>
@@ -986,7 +1022,7 @@ namespace yy {
   // by_type.
   inline
   sieve_parser::by_type::by_type ()
-     : type (empty)
+    : type (empty_symbol)
   {}
 
   inline
@@ -1001,10 +1037,17 @@ namespace yy {
 
   inline
   void
+  sieve_parser::by_type::clear ()
+  {
+    type = empty_symbol;
+  }
+
+  inline
+  void
   sieve_parser::by_type::move (by_type& that)
   {
     type = that.type;
-    that.type = empty;
+    that.clear ();
   }
 
   inline
@@ -1166,7 +1209,7 @@ namespace yy {
 
 
 } // yy
-#line 1170 "gen/sieve_parser.tab.hh" // lalr1.cc:387
+#line 1213 "gen/sieve_parser.tab.hh" // lalr1.cc:392
 
 
 

--- a/gen/stack.hh
+++ b/gen/stack.hh
@@ -1,8 +1,8 @@
-// A Bison parser, made by GNU Bison 3.0.2.
+// A Bison parser, made by GNU Bison 3.0.4.
 
 // Stack handling for Bison parsers in C++
 
-// Copyright (C) 2002-2013 Free Software Foundation, Inc.
+// Copyright (C) 2002-2015 Free Software Foundation, Inc.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@
 
 
 namespace yy {
-#line 46 "gen/stack.hh" // stack.hh:152
+#line 46 "gen/stack.hh" // stack.hh:151
   template <class T, class S = std::vector<T> >
   class stack
   {
@@ -54,12 +54,12 @@ namespace yy {
     stack ()
       : seq_ ()
     {
+      seq_.reserve (200);
     }
 
     stack (unsigned int n)
       : seq_ (n)
-    {
-    }
+    {}
 
     inline
     T&
@@ -136,8 +136,7 @@ namespace yy {
     slice (const S& stack, unsigned int range)
       : stack_ (stack)
       , range_ (range)
-    {
-    }
+    {}
 
     inline
     const T&
@@ -153,6 +152,6 @@ namespace yy {
 
 
 } // yy
-#line 157 "gen/stack.hh" // stack.hh:152
+#line 156 "gen/stack.hh" // stack.hh:151
 
 #endif // !YY_YY_GEN_STACK_HH_INCLUDED

--- a/src/sieve_parser.yy
+++ b/src/sieve_parser.yy
@@ -150,9 +150,29 @@ command :
                 YYABORT;
             }
 
-            if ($1 == "fileinto" && ($2.size() > 2 || $2.size() < 1)) {
-                driver.error(@2, "Incorrect arguments to \"fileinto\" command.", "Syntax:   fileinto [\":flags\"][\":copy\"] <folder: string>");
-                YYABORT;
+            if ($1 == "fileinto") {
+                std::string suggestion = "Syntax:   fileinto [\":flags\" <list-of-flags: string-list>][\":copy\"] <folder: string>";
+
+                if ($2.size() < 1) {
+                    driver.error(@2, "Incorrect arguments to \"fileinto\" command.", suggestion);
+                    YYABORT;
+                }
+
+                int minArguments = 1;
+
+                if (std::find($2.begin(), $2.end(), ":flags") != $2.end()) {
+                    minArguments += 2;
+                }
+
+                if (std::find($2.begin(), $2.end(), ":copy") != $2.end()) {
+                    minArguments++;
+                }
+
+                // verify minimum number of arguments
+                if ($2.size() < minArguments) {
+                    driver.error(@2, "Incorrect number of arguments to \"fileinto\" command.", suggestion);
+                    YYABORT;
+                }
             }
 
             if ($1 == "redirect" && ($2.size() > 2 || $2.size() < 1)) {

--- a/src/sieve_parser.yy
+++ b/src/sieve_parser.yy
@@ -1,5 +1,5 @@
 %skeleton "lalr1.cc" /* -*- C++ -*- */
-%require "3.0.2"
+%require "3.0.4"
 %defines
 %define parser_class_name {sieve_parser}
 

--- a/test/5232/fileinto_test.py
+++ b/test/5232/fileinto_test.py
@@ -1,0 +1,47 @@
+import sys
+sys.path.append('./')
+
+import unittest
+import checksieve
+
+class TestFileinto(unittest.TestCase):
+    
+    def test_fileinto_with_flags(self):
+        sieve = '''
+        require ["fileinto", "imap4flags"];
+        fileinto :flags "\\\\Seen" "Mailbox";
+        '''
+        self.assertFalse(checksieve.parse_string(sieve, False))
+    
+    def test_fileinto_with_flags_list(self):
+        sieve = '''
+        require ["fileinto", "imap4flags"];
+        fileinto :flags ["\\\\Seen", "\\\\Deleted"] "Mailbox";
+        '''
+        self.assertFalse(checksieve.parse_string(sieve, False))
+    
+    def test_fileinto_with_flags_without_arguments(self):
+        sieve = '''
+        require ["fileinto", "imap4flags"];
+        fileinto :flags "Mailbox";
+        '''
+        self.assertTrue(checksieve.parse_string(sieve, True))
+    
+    def test_fileinto_with_flag_and_copy(self):
+        sieve = '''
+        require ["fileinto", "imap4flags", "copy"];
+        fileinto :flags "\\\\Seen" :copy "Mailbox";
+        '''
+        self.assertFalse(checksieve.parse_string(sieve, False))
+    
+    def test_fileinto_with_flag_without_arguments_and_copy(self):
+        sieve = '''
+        require ["fileinto", "imap4flags", "copy"];
+        fileinto :flags :copy "Mailbox";
+        '''
+        self.assertTrue(checksieve.parse_string(sieve, True))
+    
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
[RFC 5232](https://tools.ietf.org/html/rfc5232) supports specifying a string-list of IMAP flags to the `fileinto` command via the [`:flags tag`](https://tools.ietf.org/html/rfc5232#section-5), but check-sieve does not properly parse this.

The usage is currently

    fileinto [\":flags\"][\":copy\"] <folder: string>"

but should be

    fileinto [\":flags\" <list-of-flags: string-list>][\":copy\"] <folder: string>

Test cases reproducing the issue and proposed fix below. See my commit messages for details, including an explanation of why the bison version changed from 3.0.2 to 3.0.4.