### PR TITLE
Fixes to make test run on Python 3.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ libchecksieve.a: $(GENERATED_SRC) $(LIBCHECKSIEVE_SRC) $(AST_SRC)
 	ar rc libchecksieve.a $(GENERATED_OBJ) $(LIBCHECKSIEVE_OBJ) $(AST_OBJ)
 
 checksieve.so: $(BASE)/src/python.cc libchecksieve.a
-	python $(BASE)/test/setup.py build_ext -i
+	python3 $(BASE)/test/setup.py build_ext -i
 
 test: libchecksieve.a checksieve.so check-sieve
-	python -m unittest discover -s test -p '*_test.py'
+	python3 -m unittest discover -s test -p '*_test.py'
 
 install: all
 	mkdir -p $(INSTALL_PREFIX)/bin

--- a/src/python.cc
+++ b/src/python.cc
@@ -37,7 +37,7 @@ static struct PyModuleDef moduledef = {
     NULL,
 };
 
-#define PY_MODCREATE() PyModule_Create(&moduledef)
+#define PY_MODCREATE() return PyModule_Create(&moduledef)
 #else
 #define PY_MODINIT(name) PyMODINIT_FUNC init##name(void)
 #define PY_MODCREATE() Py_InitModule3( PY_MODNAME, checksieve_methods, PY_MODDESC )
@@ -68,9 +68,9 @@ static PyObject *parse_string_with_options(PyObject *self, PyObject *args) {
         return NULL;
 
     // Pull out max line length
-    value = PyDict_GetItem(options, PyString_FromString("string_list_max_length"));
+    value = PyDict_GetItem(options, PyUnicode_FromString("string_list_max_length"));
     if (value != NULL) {
-        opts.string_list_max_length = int(PyInt_AsLong(value));
+        opts.string_list_max_length = int(PyLong_AsLong(value));
     }
 
     sieve::driver driver(opts);

--- a/test/AST/commands_test.py
+++ b/test/AST/commands_test.py
@@ -1,9 +1,6 @@
-import sys
-sys.path.append('./')
-
 import unittest
 import checksieve
-import util
+from . import util
 
 class TestCommandsAST(util.DiffTestCase):
     

--- a/test/AST/control_test.py
+++ b/test/AST/control_test.py
@@ -1,9 +1,6 @@
-import sys
-sys.path.append('./')
-
 import unittest
 import checksieve
-import util
+from . import util
 
 class TestControlAST(util.DiffTestCase):
     


### PR DESCRIPTION
I didn't do all the #ifdefs to make this compatible with Python2, but Python2 is EOL in [less than a year](https://pythonclock.org/) anyway.