### PR TITLE
accept relational operators in header tests

### DIFF
--- a/src/AST/Validation/Test.cc
+++ b/src/AST/Validation/Test.cc
@@ -173,7 +173,9 @@ bool Test::_validateHeaderTest(const ASTNode *node) {
                 tagValue == ":subtype" ||
                 tagValue == ":contenttype" ||
                 tagValue == ":param" ||
-                tagValue == ":regex") {
+                tagValue == ":regex" ||
+                tagValue == ":value" ||
+                tagValue == ":count") {
                     continue;
                 }
             

--- a/test/5231/relational_test.py
+++ b/test/5231/relational_test.py
@@ -40,6 +40,17 @@ class TestRelational(unittest.TestCase):
         '''
         self.assertFalse(checksieve.parse_string(sieve, False))
 
+    def test_header_test_value(self):
+        sieve = '''
+          require ["relational", "comparator-i;ascii-numeric", "fileinto"];
+          if header :value "lt" :comparator "i;ascii-numeric"
+             ["x-priority"] ["3"]
+          {
+             fileinto "Priority";
+          }
+        '''
+        self.assertFalse(checksieve.parse_string(sieve, False))
+
     def test_value_no_require(self):
         sieve = '''
            require ["fileinto"];


### PR DESCRIPTION
Include the the :value and :count match types specified by RFC 5231 in the validation of header tests.

Add the header test example provided by RFC 5231 to the relational unit test.