### PR TITLE
Add Snapcraft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ __pycache__
 # Web-related binaries
 *.js
 *.wasm
+
+# Snaps
+*.snap
+*.snap.bak

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ to the desired location.
 
 * Arch Linux ([community](https://archlinux.org/packages/community/x86_64/check-sieve/) repository)
 
+
+##### Snap
+To build the snap, run `snapcraft`.
+Installation of the locally-built snap requires the following:
+```
+sudo snap install --dangerous --devmode check-sieve_X.X_amd64.snap
+```
+
 #### Supported RFCs
 
 Currently, the supported RFCs are:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,52 @@
+name: check-sieve
+version: "0.6"
+summary: Syntax checker for mail sieves
+description: |
+  Makes checking mail sieve syntax easy and painless.
+  Because breaking your sieve in production sucks.
+
+type: app
+base: core22
+grade: stable
+compression: xz
+
+confinement: strict
+adopt-info: check-sieve
+
+parts:
+  check-sieve:
+    plugin: make
+    source: https://github.com/dburkart/check-sieve.git
+    build-packages:
+      - g++
+      - gcc
+      - make
+      - bison
+      - flex
+      - python3-dev
+    override-pull: |
+      craftctl default
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_version="$(echo "${last_committed_tag}" | grep -Eo '[[:digit:]]+\.[[:digit:]]+')"
+      last_released_version="$(snap info $CRAFT_PROJECT_NAME | awk '$1 == "latest/beta:" { print $2 }' || true)"
+      
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_version}" != "${last_released_version}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+        echo "Setting version to ${last_committed_version}"
+        craftctl set version="${last_committed_version}"
+      else
+        echo "Setting version to $(git rev-parse --short HEAD)"
+        craftctl set version="$(git rev-parse --short HEAD)"
+      fi
+    override-build: |
+      CFLAGS='-O3 -pipe' make -j4
+      cp check-sieve $CRAFT_PART_INSTALL
+
+apps:
+  check-sieve:
+    command: check-sieve
+    plugs:
+      - home # access to user's /home directory

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: check-sieve
 license: MIT
-version: "0.6"
+version: "0.8" # automatically updated during pull
 summary: Syntax checker for mail sieves
 description: |
   Makes checking mail sieve syntax easy and painless.
@@ -22,9 +22,6 @@ parts:
       - g++
       - gcc
       - make
-      - bison
-      - flex
-      - python3-dev
     override-pull: |
       craftctl default
       last_committed_tag="$(git describe --tags --abbrev=0)"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: check-sieve
+license: MIT
 version: "0.6"
 summary: Syntax checker for mail sieves
 description: |


### PR DESCRIPTION
This pull request implements a [Snapcraft][snapcraft] definition for the check-sieve application as an alternative distribution and packaging method. Snaps are one of the many handy and portable ways of targeting [several Linux distributions][versions] simultaneously for consumption.

The definition overrides the `pull` strategy to extract the version information from the last tag automatically. When the version is not published, it will jump to that tag for the build (e.g., `8.0`); otherwise, it will produce a build tagged with the commit identifier (e.g., `704d7c2`). The override suits CI/CD and automated GitHub workflow publishing.

Lastly, the package is fairly lightweight:

- **The executable itself**: `ls -lh check-sieve`
```
-rwxrwxr-x 1 jlettman jlettman 1.2M Sep  1 16:07 check-sieve
```

- **The snap**: `$ ls -lh check-sieve_v0.8_amd64.snap`
```
-rw-r--r-- 1 jlettman jlettman 136K Sep  1 19:55 check-sieve_v0.8_amd64.snap
```

This arises, most likely, from the compression and high optimization flags.

[snapcraft]: https://snapcraft.io/
[versions]: https://repology.org/project/snapd/versions

## Example
`$ snap info check-sieve`
```
name:      check-sieve
summary:   Syntax checker for mail sieves
publisher: –
license:   unset (*)
description: |
  Makes checking mail sieve syntax easy and painless.
  Because breaking your sieve in production sucks.
commands:
  - check-sieve
refresh-date: today at 19:55 EDT
installed:    v0.8 (x1) 139kB devmode
```
<sup><sub>(*) follow-up commit will fix license metadata</sub></sup>

`$ rcat test.sieve`
```sieve
require ["copy", "environment", "imapsieve"];

if anyof (environment :is "imap.cause" "APPEND",
        environment :is "imap.cause" "COPY")  {
if environment :is "imap.mailbox" "ActionItems" {
        redirect :copy "actionitems@example.com";
}
}
```

`$ /snap/bin/check-sieve test.sieve`
```
test.sieve: No errors found!
```