### PR TITLE
Implement RFC 6134 Sieve Extension: Externally Stored Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Currently, the supported RFCs are:
 * Environment Extension ([RFC 5183](https://tools.ietf.org/html/rfc5183))
 * Sieve Notification Mechanism: mailto ([RFC 5436](https://tools.ietf.org/html/rfc5436))
 * Internet Message Access Protocol (IMAP) Events ([RFC 6785](https://tools.ietf.org/html/rfc6785))
-* Converting Messages before Delivery ([6558](https://tools.ietf.org/html/rfc6558))
+* Converting Messages before Delivery ([RFC 6558](https://tools.ietf.org/html/rfc6558))
+* Externally Stored Lists ([RFC 6134](https://tools.ietf.org/html/rfc6134))
 * Proton Expiration Extension ([vnd.proton.expire](https://proton.me/support/sieve-advanced-custom-filters#managing-expiration))
 * Proton Eval Extension ([vnd.proton.eval](https://proton.me/support/sieve-advanced-custom-filters#transforming-variables))
 

--- a/docs/man1/check-sieve.1
+++ b/docs/man1/check-sieve.1
@@ -98,4 +98,6 @@ Sieve Notification Mechanism: mailto (RFC 5436)
 Internet Message Access Protocol (IMAP) Events (RFC 6785)
 .br
 Converting Messages before Delivery (RFC 6558)
+.br
+Externally Stored Lists (RFC 6134)
 .RE

--- a/src/AST/ASTVerificationVisitor.cc
+++ b/src/AST/ASTVerificationVisitor.cc
@@ -458,6 +458,12 @@ void ASTVerificationVisitor::_enable_capability(const std::string& capability) {
         _test_map["convert"] = true;
     }
 
+    // "extlists"
+    // RFC 6134
+    if (capability == "extlists") {
+        _tag_map[":list"] = true;
+    }
+
     // DRAFT RFCs
 
     // "regex"

--- a/src/AST/ASTVerificationVisitor.cc
+++ b/src/AST/ASTVerificationVisitor.cc
@@ -462,6 +462,7 @@ void ASTVerificationVisitor::_enable_capability(const std::string& capability) {
     // RFC 6134
     if (capability == "extlists") {
         _tag_map[":list"] = true;
+        _test_map["valid_ext_list"] = true;
     }
 
     // DRAFT RFCs

--- a/src/AST/Validation/Command.cc
+++ b/src/AST/Validation/Command.cc
@@ -32,7 +32,7 @@ Command::Command() {
     _usage_map["include"] = "include [:global / :personal] [:once] [:optional] <value: string>";
     _usage_map["keep"] = "keep [:flags <list-of-flags: string-list>]";
     _usage_map["notify"] = "notify [:from string] [:importance <1 / 2 / 3>] [:options string-list] [:message string] <method: string>";
-    _usage_map["redirect"] = "redirect [:copy] <address: string>";
+    _usage_map["redirect"] = "redirect [:copy / :list] <address: string>";
     _usage_map["reject"] = "reject <reason: string>";
     _usage_map["removeflag"] = "removeflag [<variablename: string>] <list-of-flags: string-list>";
     _usage_map["replace"] = "replace [:mime] [:subject string] [:from string] <replacement: string>";
@@ -319,7 +319,8 @@ bool Command::_validateRedirectCommand(const ASTNode *node) {
     
     int numArguments = 1;
     
-    if (command->find(ASTTag(":copy")) != command->children().end()) {
+    if (command->find(ASTTag(":copy")) != command->children().end() ||
+        command->find(ASTTag(":list")) != command->children().end()) {
         numArguments += 1;
     }
     

--- a/src/AST/Validation/Tag.cc
+++ b/src/AST/Validation/Tag.cc
@@ -1,3 +1,4 @@
+#include "ASTNode.hh"
 #include "ASTNumeric.hh"
 #include "ASTString.hh"
 #include "Tag.hh"
@@ -9,11 +10,13 @@ Tag::Tag() {
     _usage_map[":days"] = ":days number";
     _usage_map[":subject"] = ":subject string";
     _usage_map[":eval"] = ":eval string";
+    _usage_map[":list"] = ":list string";
 
     _validation_fn_map[":comparator"] = &Tag::_validateSingleString; // TODO: Validate comparator string
     _validation_fn_map[":days"] = &Tag::_validateSingleNumeric;
     _validation_fn_map[":subject"] = &Tag::_validateSingleString;
     _validation_fn_map[":eval"] = &Tag::_validateSingleString;
+    _validation_fn_map[":list"] = &Tag::_validateList;
 }
 
 bool Tag::validate(const ASTNode *node) {
@@ -65,6 +68,22 @@ bool Tag::_validateSingleNumeric(const ASTNode *node) {
     }
     
     return true;
+}
+
+bool Tag::_validateList(const ASTNode *node) {
+    const auto *tag = dynamic_cast<const ASTTag*>(node);
+    const ASTNode *parent = tag->parent();
+    const ASTNode *next = parent->nextChild(tag);
+
+    if (dynamic_cast<const ASTString *>(next) != nullptr) {
+        return true;
+    }
+
+    if (dynamic_cast<const ASTStringList *>(next) != nullptr) {
+        return true;
+    }
+
+    return false;
 }
 
 }

--- a/src/AST/Validation/Tag.hh
+++ b/src/AST/Validation/Tag.hh
@@ -22,6 +22,7 @@ private:
     // Validation functions
     bool _validateSingleString(const ASTNode *node);
     bool _validateSingleNumeric(const ASTNode *node);
+    bool _validateList(const ASTNode *node);
     
     std::map<std::string, bool (Tag::*)(const ASTNode *)> _validation_fn_map;
     std::map<std::string, std::string> _usage_map;

--- a/src/AST/Validation/Test.cc
+++ b/src/AST/Validation/Test.cc
@@ -214,7 +214,9 @@ bool Test::_validateHeaderTest(const ASTNode *node) {
                 tagValue == ":param" ||
                 tagValue == ":regex" ||
                 tagValue == ":value" ||
-                tagValue == ":count") {
+                tagValue == ":count" ||
+                tagValue == ":index" ||
+                tagValue == ":list") {
                     continue;
                 }
             

--- a/src/AST/Validation/Test.cc
+++ b/src/AST/Validation/Test.cc
@@ -34,6 +34,7 @@ Test::Test() {
     _usage_map["not"]                   = "not <test1: test>";
     _usage_map["size"]                  = "size <:over / :under> <limit: number>";
     _usage_map["valid_notify_method"]   = "valid_notify_method <notification-uris: string-list>";
+    _usage_map["valid_ext_list"]        = "valid_ext_list <ext-list-names: string-list>";
 
     _validation_fn_map["allof"]                 = &Test::_validateHasOnlyTestList;
     _validation_fn_map["anyof"]                 = &Test::_validateHasOnlyTestList;
@@ -46,6 +47,7 @@ Test::Test() {
     _validation_fn_map["not"]                   = &Test::_validateNotTest;
     _validation_fn_map["size"]                  = &Test::_validateSizeTest;
     _validation_fn_map["valid_notify_method"]   = &Test::_validateValidNotifyMethodTest;
+    _validation_fn_map["valid_ext_list"]        = &Test::_validateValidExtListTest;
 }
 
 bool Test::validate(const ASTNode *node) {
@@ -285,5 +287,16 @@ bool Test::_validateEnvironmentTest(const ASTNode *node) {
     
     return false;
 }
+
+bool Test::_validateValidExtListTest(const ASTNode *node) {
+    const auto *test = dynamic_cast<const ASTTest*>(node);
+    size_t size = test->children().size();
+    
+    if (!nodeIsType<ASTStringList>(test->children()[0]) && !nodeIsType<ASTString>(test->children()[0]))
+        return false;
+    
+    return true;
+}
+
 
 }

--- a/src/AST/Validation/Test.hh
+++ b/src/AST/Validation/Test.hh
@@ -30,7 +30,8 @@ private:
     bool _validateExpirationTest(const ASTNode *node);
     bool _validateHeaderTest(const ASTNode *node);
     bool _validateIhaveTest(const ASTNode *node);
-    bool _validateEnvironmentTest (const ASTNode *node);
+    bool _validateEnvironmentTest(const ASTNode *node);
+    bool _validateValidExtListTest(const ASTNode *node);
 
     std::map<std::string, bool (Test::*)(const ASTNode *)> _validation_fn_map;
     std::map<std::string, std::string> _usage_map;

--- a/test/6134/examples_test.py
+++ b/test/6134/examples_test.py
@@ -1,0 +1,104 @@
+import unittest
+import checksieve
+
+
+class TestExamples(unittest.TestCase):
+    def test_example_1a(self):
+        sieve = """
+            require ["envelope", "extlists", "fileinto", "spamtest",
+                     "relational", "comparator-i;ascii-numeric"];
+            if envelope :list "from" ":addrbook:default"
+            { /* Known: allow high spam score */
+                if spamtest :value "ge" :comparator "i;ascii-numeric" "8"
+                {
+                    fileinto "spam";
+                }
+            }
+            elsif spamtest :value "ge" :comparator "i;ascii-numeric" "3"
+            { /* Unknown: less tolerance in spam score */
+                fileinto "spam";
+            }
+        """
+        self.assertFalse(checksieve.parse_string(sieve, False))
+
+    def test_example_1b(self):
+        sieve = """
+            require ["envelope", "extlists", "fileinto", "spamtest",
+                "variables", "relational", "comparator-i;ascii-numeric"];
+            if envelope :list "from" ":addrbook:default" {
+                set "lim" "8";  /* Known: allow high spam score */
+            } else {
+                set "lim" "3";  /* Unknown: less tolerance in spam score */
+            }
+            if spamtest :value "ge" :comparator "i;ascii-numeric" "${lim}" {
+                fileinto "spam";
+            }
+        """
+        self.assertFalse(checksieve.parse_string(sieve, False))
+
+    def test_example_2(self):
+        sieve = """
+            require ["extlists", "date", "enotify"];
+            if currentdate :list "date"
+                "tag:example.com,2011-01-01:localHolidays" {
+                notify "xmpp:romeo@im.example.com";
+            }
+        """
+        self.assertFalse(checksieve.parse_string(sieve, False))
+
+    def test_example_3(self):
+        sieve = """
+            require ["extlists", "envelope", "subaddress"];
+
+            # Submission from list members is sent to all members
+            if allof (envelope :detail "to" "mylist",
+                        header :list "from"
+                                "tag:example.com,2010-05-28:mylist") {
+                redirect :list "tag:example.com,2010-05-28:mylist";
+            }
+        """
+        self.assertFalse(checksieve.parse_string(sieve, False))
+
+    def test_example_4(self):
+        sieve = """
+            require ["variables", "extlists", "index", "reject"];
+            if header :index 1 :matches "received" "*(* [*.*.*.*])*" {
+                set "ip" "${3}.${4}.${5}.${6}";
+                if string :list "${ip}"
+                    "tag:example.com,2011-04-10:DisallowedIPs" {
+                reject "Message not allowed from this IP address";
+                }
+            }
+        """
+        self.assertFalse(checksieve.parse_string(sieve, False))
+
+    def test_example_5(self):
+        sieve = """
+            require [ "extlists", "foreverypart", "mime", "enclose" ];
+
+            foreverypart
+            {
+                if header :mime :param "filename"
+                    :list ["Content-Type", "Content-Disposition"]
+                    "tag:example.com,2011-04-10:BadFileNameExts"
+                {
+                # these attachment types are executable
+                enclose :subject "Warning" :text
+            WARNING! The enclosed message has attachments that might be unsafe.
+            These attachment types may contain a computer virus program
+            that can infect your computer and potentially damage your data.
+
+            Before clicking on these message attachments, you should verify
+            with the sender that this message was sent intentionally, and
+            that the attachments are safe to open.
+            .
+            ;
+                break;
+                }
+            }
+        """
+        self.assertFalse(checksieve.parse_string(sieve, False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/6134/examples_test.py
+++ b/test/6134/examples_test.py
@@ -74,28 +74,28 @@ class TestExamples(unittest.TestCase):
 
     def test_example_5(self):
         sieve = """
-            require [ "extlists", "foreverypart", "mime", "enclose" ];
+require [ "extlists", "foreverypart", "mime", "enclose" ];
 
-            foreverypart
-            {
-                if header :mime :param "filename"
-                    :list ["Content-Type", "Content-Disposition"]
-                    "tag:example.com,2011-04-10:BadFileNameExts"
-                {
-                # these attachment types are executable
-                enclose :subject "Warning" :text
-            WARNING! The enclosed message has attachments that might be unsafe.
-            These attachment types may contain a computer virus program
-            that can infect your computer and potentially damage your data.
+foreverypart
+{
+    if header :mime :param "filename"
+        :list ["Content-Type", "Content-Disposition"]
+        "tag:example.com,2011-04-10:BadFileNameExts"
+    {
+    # these attachment types are executable
+    enclose :subject "Warning" text:
+WARNING! The enclosed message has attachments that might be unsafe.
+These attachment types may contain a computer virus program
+that can infect your computer and potentially damage your data.
 
-            Before clicking on these message attachments, you should verify
-            with the sender that this message was sent intentionally, and
-            that the attachments are safe to open.
-            .
-            ;
-                break;
-                }
-            }
+Before clicking on these message attachments, you should verify
+with the sender that this message was sent intentionally, and
+that the attachments are safe to open.
+.
+;
+    break;
+    }
+}
         """
         self.assertFalse(checksieve.parse_string(sieve, False))
 

--- a/test/6134/valid_ext_lists_test.py
+++ b/test/6134/valid_ext_lists_test.py
@@ -1,0 +1,22 @@
+import unittest
+import checksieve
+
+
+class TestValidExtList(unittest.TestCase):
+    def test_valid_ext_list(self):
+        sieve = """
+            require ["extlists", "reject"];
+            if valid_ext_list ":addrbook:default"
+            {
+                reject "Sorry, only friends and work!";
+            }
+            elsif valid_ext_list [":addrbook:frens", ":addrbook:work"]
+            {
+                stop;
+            }
+        """
+        self.assertFalse(checksieve.parse_string(sieve, False))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> [!IMPORTANT]
> The change is blocked by a unique grammar element for multi-line strings missing from the Bison declarations. See: https://github.com/dburkart/check-sieve/issues/55#issuecomment-1703683448

This change implements support for [_RFC 6134 Sieve Extension: Externally Stored Lists_][rfc6134], closing #55.
The RFC introduces the following elements:
- **[`:list` tag][list]** (match type for supported tests)
  > The new ":list" match type changes the interpretation of the "key-list" parameter (the second parameter) in supported tests.  When the match type is ":list", the key-list becomes a list of names of externally stored lists.  The external lists are queried, perhaps through a list-specific mechanism, and the test evaluates to "true" if any of the specified values matches any member of one or more of the lists.
- **[`valid_ext_list` test][valid_ext_list]**
  > The "valid_ext_list" test is true if all of the external list names in the ext-list-names argument are supported, and they are valid both syntactically (including URI parameters) and semantically (including implementation-specific semantic restrictions).  Otherwise, the test returns false.

  > This test MUST perform exactly the same validation of an external list name as would be performed by the "header :list" test.

[rfc6134]: https://datatracker.ietf.org/doc/html/rfc6134
[list]: https://datatracker.ietf.org/doc/html/rfc6134#section-2.2
[valid_ext_list]: https://datatracker.ietf.org/doc/html/rfc6134#section-2.7