### PR TITLE
Fix MailServer compilation error (see #52)

### DIFF
--- a/src/Server/MailServer.hh
+++ b/src/Server/MailServer.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <map>
 #include <vector>


### PR DESCRIPTION
PR #53 fixed compilation for GCC 13 this but not in all files, compilation still failed for me.
This commit fixes that by explicitly including `cstdint`.