### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,5 +1,8 @@
 name: C/C++ CI
 
+permissions:
+  contents: read
+
 on: [push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/dburkart/check-sieve/security/code-scanning/3](https://github.com/dburkart/check-sieve/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required scopes to `GITHUB_TOKEN`. For this workflow, the jobs only need to read the repository contents to build and test the code. They do not perform any write operations to GitHub (no issue updates, no PR changes, no artifact uploads requiring elevated scopes, etc.), so `contents: read` at the workflow level is sufficient.

The single best fix without changing existing functionality is to add a root-level `permissions:` block just under the `name:` (or `on:`) key in `.github/workflows/c-cpp.yml`, setting `contents: read`. This will apply to both `ubuntu_matrix` and `macos_matrix` because they do not define their own `permissions` blocks. No additional imports or methods are required, as this is purely a YAML configuration change.

Concretely, in `.github/workflows/c-cpp.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: C/C++ CI` and `on: [push]` lines. No other lines need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
