### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,4 +1,6 @@
 name: C/C++ CI
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/dburkart/check-sieve/security/code-scanning/2](https://github.com/dburkart/check-sieve/security/code-scanning/2)

In general, the fix is to explicitly declare restricted `GITHUB_TOKEN` permissions for the workflow or for each job, instead of relying on repository defaults. For a pure CI build-and-test workflow like this, `contents: read` is sufficient: it allows `actions/checkout` to read the repository code but prevents unnecessary write operations.

The best minimal fix without changing existing behavior is:
- Add a top-level `permissions:` block applying to all jobs, directly under `name:` (or under `on:`), setting `contents: read`.
- This ensures both `ubuntu_matrix` and `macos_matrix` jobs run with a read-only token and documents the intended minimal privilege.

Concretely, in `.github/workflows/c-cpp.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `name: C/C++ CI` line (line 1) and before the `on: [push]` line (line 3). No imports, methods, or other code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
