### PR TITLE
Check write return value for errors

### DIFF
--- a/src/sieve.cc
+++ b/src/sieve.cc
@@ -269,7 +269,12 @@ int main( int argc, char *argv[] ) {
                     failures++;
                     char tmpname[] = "/tmp/check-sieve-XXXXXX";
                     int fd = mkstemp(tmpname);
-                    write(fd, stripped.c_str(), stripped.size());
+                    if (write(fd, stripped.c_str(), stripped.size()) < 0) {
+                        std::cerr << "Failed writing to temporary file at "
+                                  << tmpname << ": "
+                                  << std::strerror(errno) << "\n";
+                        abort();
+                    }
                     close(fd);
                     std::string expected_arg = out_exists ? out_path : "/dev/null";
                     std::string cmd = "diff -ubBd " + expected_arg + " " + std::string(tmpname);


### PR DESCRIPTION
This fixes an unused-result error on 1.0.0 when using write() due to missing return value handling.

```
> g++ -c -I../gen/ -I../src/ -I../src/AST -I../src/Server -I../src/Email -std=c++17 -fPIC -Wno-deprecated-register -DPLATFORM=\"x86_64-Linux\" -Werror -Wall ../src/sieve.cc -o ../src/sieve.o
> ../src/sieve.cc: In function 'int main(int, char**)':
> ../src/sieve.cc:272:26: error: ignoring return value of 'ssize_t write(int, const void*, size_t)' declared with attribute 'warn_unused_result' [-Werror=unused-result]
>   272 |                     write(fd, stripped.c_str(), stripped.size());
>       |                     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
